### PR TITLE
Nix: full featured flake with home-manager options and a devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "A development environment for this python project";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+
+      perSystem = { self', pkgs, ... }:
+      {
+        formatter = pkgs.nixfmt-rfc-style;
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ python3 ];
+        };
+        
+        packages = {
+          default = self'.packages.pogit;
+          pogit = pkgs.callPackage ./nix { };
+        };
+      };
+
+      flake.homeManagerModules = {
+        default = inputs.self.homeManagerModules.pogit;
+        pogit = import ./nix/hm-module.nix inputs.self;
+      };
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,9 @@
+{
+  python3,
+  ...
+}:
+python3.pkgs.buildPythonApplication {
+  name = "pogit";
+  version = "0.5.0";
+  src = ../.;
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,46 @@
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.types) nullOr package;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
+  inherit (lib.modules) mkIf;
+
+  cfg = config.programs.pogit;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.pogit = {
+    enable = mkEnableOption "pogit";
+    package = mkOption {
+      type = package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.pogit;
+    };
+    config = mkOption {
+      type = nullOr tomlFormat.type;
+      default = { }; 
+      description = ''
+        Add custom commits to extend pogit.
+      '';
+      example = literalExpression ''
+        {
+          format = "...";
+          cat = {
+            icon = "🐶";
+            default_msg = "dog";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."pogit/pogit.toml" = mkIf (cfg.config != { }) {
+      source = tomlFormat.generate "pogit-config" cfg.config;
+    };
+  };
+}


### PR DESCRIPTION
I made a nix flake which packages the project, there's also a devshell for `nix develop`.

I also added `home-manager` options to configure custom commits in the future.

It can be setup like this:
```nix
{ inputs, ... }:
{
  imports = [
    # Importing the module to have access to options.
    inputs.pogit.homeManagerModules.default
  ];

  programs.pogit = {
    enable = true;
    #package = inputs.pogit.packages.${pkgs.system}.pogit; # Default package can be changed here.
    config = {
      format = "TODO"; # To format the text
      custom-commit-name = {
        icon = "🐶";
        default_msg = "a default message.";
      };
    };
  };
}
```
This block of nix code will generate a `.toml` file and symlink it in `$XDG_CONFIG_HOME/pogit/pogit.toml`.

The code above is translated like this:
```toml
format = "TODO"

[custom-commit-name]
icon = "🐶"
default_msg = "a default message."
```