### PR TITLE
「🔨」 fix(nix): added git as a dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,30 @@
 {
-  description = "A development environment for this python project";
+  description = "🌸 a git wrapper for cute commits.";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs:
+  outputs =
+    inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-      perSystem = { self', pkgs, ... }:
-      {
-        formatter = pkgs.nixfmt-rfc-style;
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [ python3 ];
+      perSystem =
+        { self', pkgs, ... }:
+        {
+          formatter = pkgs.nixfmt-rfc-style;
+          devShells.default = pkgs.mkShell { packages = self'.packages.pogit.nativeBuildInputs; };
+
+          packages = {
+            default = self'.packages.pogit;
+            pogit = pkgs.callPackage ./nix { };
+          };
         };
-        
-        packages = {
-          default = self'.packages.pogit;
-          pogit = pkgs.callPackage ./nix { };
-        };
-      };
 
       flake.homeManagerModules = {
         default = inputs.self.homeManagerModules.pogit;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,9 +1,11 @@
 {
   python3,
+  git,
   ...
 }:
 python3.pkgs.buildPythonApplication {
   name = "pogit";
   version = "0.6.2";
   src = ../.;
+  nativeBuildInputs = [ git ];
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,4 +1,5 @@
-self: {
+self:
+{
   config,
   lib,
   pkgs,
@@ -21,7 +22,7 @@ in
     };
     config = mkOption {
       type = nullOr tomlFormat.type;
-      default = { }; 
+      default = { };
       description = ''
         Add custom commits to extend pogit.
       '';


### PR DESCRIPTION
# Fixes #4
It adds git as a dependency for the devShell and the package itself.
It is required because pogit call the git binary when executed which could not be find if the user did not have git installed next to pogit.